### PR TITLE
feat: customizable composability poc

### DIFF
--- a/op-node/rollup/derive/attributes.go
+++ b/op-node/rollup/derive/attributes.go
@@ -79,7 +79,6 @@ func (ba *FetchingAttributesBuilder) PreparePayloadAttributes(ctx context.Contex
 			return nil, NewCriticalError(fmt.Errorf("failed to apply derived L1 sysCfg updates: %w", err))
 		}
 
-		info.Hash()
 		l1Info = info
 		depositTxs = deposits
 		seqNumber = 0

--- a/op-node/rollup/derive/sync.go
+++ b/op-node/rollup/derive/sync.go
@@ -1,0 +1,154 @@
+package derive
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"math/big"
+	"strings"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+const syncABI = `[{"inputs":[],"name":"sync","outputs":[{"internalType":"address[]","name":"__targets","type":"address[]"},{"internalType":"bytes[]","name":"__retdata","type":"bytes[]"},{"internalType":"bytes32[]","name":"__hashedCalldata","type":"bytes32[]"}],"stateMutability":"nonpayable","type":"function"}]`
+const setStateABI = `[{"inputs":[{"internalType":"address[]","name":"_targets","type":"address[]"},{"internalType":"bytes[]","name":"_retdata","type":"bytes[]"},{"internalType":"bytes32[]","name":"_hashedCalldata","type":"bytes32[]"}],"name":"setState","outputs":[],"stateMutability":"nonpayable","type":"function"}]`
+
+func SyncTransactions(ctx context.Context, rollupCfg *rollup.Config, l1Client L1ReceiptsFetcher, blockNumber uint64, seqNumber uint64, hash common.Hash, l2BlockTime uint64) (hexutil.Bytes, error) {
+	var syncContract common.Address
+	var dep types.DepositTx
+	var syncTx []byte
+	// Hardcoded for now, needs to be added to rollup config
+	syncContract = common.HexToAddress("0xc448A94eE3b3Bae6e939D7a1C171597Af31cd091")
+	addressZero := common.HexToAddress("0x0000000000000000000000000000000000000000")
+
+	parsedABI, err := abi.JSON(strings.NewReader(syncABI))
+
+	if err != nil {
+		log.Fatalf("Failed to parse function call: %v", err)
+		return nil, err
+	}
+
+	data, err := parsedABI.Pack("sync")
+	if err != nil {
+		log.Fatalf("Failed to pack sync function call: %v", err)
+		return nil, err
+	}
+
+	callMsg := ethereum.CallMsg{
+		From: addressZero,
+		To:   &syncContract,
+		Data: data,
+		Gas:  1_000_000,
+	}
+
+	var result hexutil.Bytes
+
+	blockAsHex := fmt.Sprintf("0x%x", blockNumber)
+
+	args := msgToCallArgs(callMsg)
+
+	result, err = l1Client.Call(ctx, args, blockAsHex)
+
+	if err != nil {
+		log.Fatalf("Failed to call function: %v", err)
+		return nil, err
+	}
+
+	// Decode the result
+	var __targets []common.Address
+	var __retdata [][]byte
+	var __hashedCalldata []common.Hash
+
+	// Unpack the returned data into the three arrays
+	err = parsedABI.UnpackIntoInterface(&[]interface{}{&__targets, &__retdata, &__hashedCalldata}, "sync", result)
+	if err != nil {
+		log.Fatalf("Failed to unpack result: %v", err)
+		return nil, err
+	}
+
+	dep, err = BuildSyncTransaction(ctx, rollupCfg, seqNumber, hash, l2BlockTime, __hashedCalldata, __retdata, __targets)
+
+	if err != nil {
+		return nil, err
+	}
+
+	l2Tx := types.NewTx(&dep)
+
+	syncTx, err = l2Tx.MarshalBinary()
+
+	if err != nil {
+		return nil, err
+	}
+
+	return syncTx, nil
+}
+
+func BuildSyncTransaction(ctx context.Context, rollupCfg *rollup.Config, seqNumber uint64, hash common.Hash, l2BlockTime uint64, hashedCalldata []common.Hash, retdata [][]byte, targets []common.Address) (types.DepositTx, error) {
+	var err error
+	var out types.DepositTx
+
+	source := L1InfoDepositSource{
+		L1BlockHash: hash,
+		SeqNumber:   seqNumber,
+	}
+
+	address := common.HexToAddress("0x4200000000000000000000000000000000000027")
+	L1InfoDepositerAddress := common.HexToAddress("0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001")
+
+	out.To = &address
+	out.From = L1InfoDepositerAddress
+	out.SourceHash = source.SourceHash()
+	out.Mint = nil
+	out.Gas = 150_000_000
+	out.Value = big.NewInt(0)
+	out.IsSystemTransaction = true
+	out.Data = nil
+
+	parsedABI, err := abi.JSON(strings.NewReader(setStateABI))
+	if err != nil {
+		log.Fatalf("Failed to parse function call: %v", err)
+		return out, err
+	}
+
+	data, err := parsedABI.Pack("setState", targets, retdata, hashedCalldata)
+	if err != nil {
+		log.Fatalf("Failed to pack setState function call: %v", err)
+		return out, err
+	}
+
+	out.Data = data
+
+	if rollupCfg.IsRegolith(l2BlockTime) {
+		out.IsSystemTransaction = false
+		out.Gas = RegolithSystemTxGas
+	}
+
+	return out, nil
+}
+
+func msgToCallArgs(msg ethereum.CallMsg) map[string]interface{} {
+	args := map[string]interface{}{
+		"to":   msg.To.Hex(),
+		"data": hexutil.Encode(msg.Data),
+	}
+
+	if msg.From != (common.Address{}) {
+		args["from"] = msg.From.Hex()
+	}
+	if msg.Gas != 0 {
+		args["gas"] = fmt.Sprintf("0x%x", msg.Gas)
+	}
+	if msg.GasPrice != nil {
+		args["gasPrice"] = fmt.Sprintf("0x%x", msg.GasPrice)
+	}
+	if msg.Value != nil {
+		args["value"] = fmt.Sprintf("0x%x", msg.Value)
+	}
+
+	return args
+}

--- a/op-node/rollup/derive/sync.go
+++ b/op-node/rollup/derive/sync.go
@@ -23,7 +23,7 @@ func SyncTransactions(ctx context.Context, rollupCfg *rollup.Config, l1Client L1
 	var dep types.DepositTx
 	var syncTx []byte
 	// Hardcoded for now, needs to be added to rollup config
-	syncContract = common.HexToAddress("0xc448A94eE3b3Bae6e939D7a1C171597Af31cd091")
+	syncContract = common.HexToAddress("0xCd271737d57b705dD49DaF3fBa20a53d05E410d8")
 	addressZero := common.HexToAddress("0x0000000000000000000000000000000000000000")
 
 	parsedABI, err := abi.JSON(strings.NewReader(syncABI))

--- a/op-node/rollup/driver/metered_l1fetcher.go
+++ b/op-node/rollup/driver/metered_l1fetcher.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/rollup/derive"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
@@ -55,6 +56,11 @@ func (m *MeteredL1Fetcher) InfoAndTxsByHash(ctx context.Context, hash common.Has
 func (m *MeteredL1Fetcher) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error) {
 	defer m.recordTime("FetchReceipts")()
 	return m.inner.FetchReceipts(ctx, blockHash)
+}
+
+func (m *MeteredL1Fetcher) Call(ctx context.Context, msg map[string]interface{}, blockTag string) (hexutil.Bytes, error) {
+	defer m.recordTime("Call")()
+	return m.inner.Call(ctx, msg, blockTag)
 }
 
 var _ derive.L1Fetcher = (*MeteredL1Fetcher)(nil)

--- a/op-program/client/l1/client.go
+++ b/op-program/client/l1/client.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -80,4 +81,8 @@ func (o *OracleL1Client) FetchReceipts(ctx context.Context, blockHash common.Has
 func (o *OracleL1Client) InfoAndTxsByHash(ctx context.Context, hash common.Hash) (eth.BlockInfo, types.Transactions, error) {
 	info, txs := o.oracle.TransactionsByBlockHash(hash)
 	return info, txs, nil
+}
+
+func (o *OracleL1Client) Call(ctx context.Context, msg map[string]interface{}, blockTag string) (hexutil.Bytes, error) {
+	panic("not implemented")
 }

--- a/op-service/sources/eth_client.go
+++ b/op-service/sources/eth_client.go
@@ -298,6 +298,18 @@ func (s *EthClient) PayloadByLabel(ctx context.Context, label eth.BlockLabel) (*
 	return s.payloadCall(ctx, "eth_getBlockByNumber", label)
 }
 
+func (s *EthClient) Call(ctx context.Context, msg map[string]interface{}, blockTag string) (hexutil.Bytes, error) {
+	var result hexutil.Bytes
+	err := s.client.CallContext(ctx, &result, "eth_call", msg, blockTag)
+	log.Debug("eth_call", "result", result, "err", err)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
 // FetchReceipts returns a block info and all of the receipts associated with transactions in the block.
 // It verifies the receipt hash in the block header against the receipt hash of the fetched receipts
 // to ensure that the execution engine did not fail to return any receipts.

--- a/packages/contracts-bedrock/scripts/DeployImplementations.s.sol
+++ b/packages/contracts-bedrock/scripts/DeployImplementations.s.sol
@@ -7,6 +7,7 @@ import { DelayedWETH } from "src/dispute/weth/DelayedWETH.sol";
 import { PreimageOracle } from "src/cannon/PreimageOracle.sol";
 import { IPreimageOracle } from "src/cannon/interfaces/IPreimageOracle.sol";
 import { MIPS } from "src/cannon/MIPS.sol";
+import { Sync } from "src/L1/Sync.sol";
 
 import { OptimismPortal2 } from "src/L1/OptimismPortal2.sol";
 import { SystemConfig } from "src/L1/SystemConfig.sol";
@@ -94,6 +95,7 @@ contract DeployImplementationsOutput {
         L1ERC721Bridge l1ERC721BridgeImpl;
         L1StandardBridge l1StandardBridgeImpl;
         OptimismMintableERC20Factory optimismMintableERC20FactoryImpl;
+        Sync sync;
     }
 
     Output internal outputs;
@@ -109,6 +111,7 @@ contract DeployImplementationsOutput {
         else if (sel == this.l1ERC721BridgeImpl.selector) outputs.l1ERC721BridgeImpl = L1ERC721Bridge(_addr);
         else if (sel == this.l1StandardBridgeImpl.selector) outputs.l1StandardBridgeImpl = L1StandardBridge(payable(_addr));
         else if (sel == this.optimismMintableERC20FactoryImpl.selector) outputs.optimismMintableERC20FactoryImpl = OptimismMintableERC20Factory(_addr);
+        else if (sel == this.sync.selector) outputs.sync = Sync(_addr);
         else revert("DeployImplementationsOutput: unknown selector");
         // forgefmt: disable-end
     }
@@ -145,6 +148,11 @@ contract DeployImplementationsOutput {
     function delayedWETHImpl() public view returns (DelayedWETH) {
         DeployUtils.assertValidContractAddress(address(outputs.delayedWETHImpl));
         return outputs.delayedWETHImpl;
+    }
+
+    function sync() public view returns (Sync) {
+        DeployUtils.assertValidContractAddress(address(outputs.sync));
+        return outputs.sync;
     }
 
     function preimageOracleSingleton() public view returns (PreimageOracle) {
@@ -217,6 +225,7 @@ contract DeployImplementations is Script {
         deployDelayedWETHImpl(_dsi, _dso);
         deployPreimageOracleSingleton(_dsi, _dso);
         deployMipsSingleton(_dsi, _dso);
+        deploySync(_dsi, _dso);
 
         _dso.checkOutput();
     }
@@ -332,6 +341,14 @@ contract DeployImplementations is Script {
 
         vm.label(address(mipsSingleton), "MIPSSingleton");
         _dso.set(_dso.mipsSingleton.selector, address(mipsSingleton));
+    }
+
+    function deploySync(DeployImplementationsInput, DeployImplementationsOutput _dso) public {
+        vm.broadcast(msg.sender);
+        Sync sync = new Sync();
+
+        vm.label(address(sync), "Sync");
+        _dso.set(_dso.sync.selector, address(sync));
     }
 
     // -------- Utilities --------

--- a/packages/contracts-bedrock/scripts/L2Genesis.s.sol
+++ b/packages/contracts-bedrock/scripts/L2Genesis.s.sol
@@ -249,6 +249,7 @@ contract L2Genesis is Deployer {
         setSchemaRegistry(); // 20
         setEAS(); // 21
         setGovernanceToken(); // 42: OP (not behind a proxy)
+        setEthereum(); // 27
         if (cfg.useInterop()) {
             setCrossL2Inbox(); // 22
             setL2ToL2CrossDomainMessenger(); // 23
@@ -271,6 +272,10 @@ contract L2Genesis is Deployer {
 
     function setL2ToL1MessagePasser() public {
         _setImplementationCode(Predeploys.L2_TO_L1_MESSAGE_PASSER);
+    }
+
+    function setEthereum() public {
+        _setImplementationCode(Predeploys.ETHEREUM);
     }
 
     /// @notice This predeploy is following the safety invariant #1.

--- a/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
+++ b/packages/contracts-bedrock/scripts/deploy/Deploy.s.sol
@@ -18,6 +18,7 @@ import { ProxyAdmin } from "src/universal/ProxyAdmin.sol";
 import { AddressManager } from "src/legacy/AddressManager.sol";
 import { Proxy } from "src/universal/Proxy.sol";
 import { L1StandardBridge } from "src/L1/L1StandardBridge.sol";
+import { Sync } from "src/L1/Sync.sol";
 import { StandardBridge } from "src/universal/StandardBridge.sol";
 import { OptimismPortal } from "src/L1/OptimismPortal.sol";
 import { OptimismPortal2 } from "src/L1/OptimismPortal2.sol";
@@ -394,6 +395,7 @@ contract Deploy is Deployer {
         deployPreimageOracle();
         deployMips();
         deployAnchorStateRegistry();
+        deploySync();
     }
 
     /// @notice Initialize all of the implementations
@@ -811,6 +813,15 @@ contract Deploy is Deployer {
         console.log("MIPS deployed at %s", address(mips));
 
         addr_ = address(mips);
+    }
+
+    function deploySync() public broadcast returns (address addr_) {
+        console.log("Deploying Sync implementation");
+        Sync sync = new Sync{ salt: _implSalt() }();
+        save("Sync", address(sync));
+        console.log("Sync deployed at %s", address(sync));
+
+        addr_ = address(sync);
     }
 
     /// @notice Deploy the AnchorStateRegistry

--- a/packages/contracts-bedrock/src/L1/Sync.sol
+++ b/packages/contracts-bedrock/src/L1/Sync.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+
+contract Sync {
+    error NotParallelArrays();
+
+    // NOTE: This is very expensive, for poc is fine, in production investigate optimizations
+    bytes[] internal _calldata;
+    bytes[] internal _retdata;
+    address[] internal _targets;
+
+    // NOTE: For the sake of poc this is left open for anyone to call, in production this should be changed
+    function setSync(bytes[] calldata __calldata, bytes[] calldata __retdata, address[] calldata __targets) external {
+         uint256 __calldataLength = __calldata.length;
+        if (__calldataLength != __retdata.length || __calldataLength != __targets.length) revert NotParallelArrays();
+
+        for (uint256 i; i < __calldataLength; i++) {
+            _calldata[i] = __calldata[i];
+            _retdata[i] = __retdata[i];
+            _targets[i] = __targets[i];
+        }
+    }
+
+    // NOTE: This function is only supposed to be called within the context of an `eth_call`
+    function sync() external returns (address[] memory __targets, bytes[] memory __retdata, bytes32[] memory __hashedCalldata) {
+        uint256 _calldataLength = _calldata.length;
+        if (_calldataLength == 0) return (__targets, __retdata, __hashedCalldata);
+
+        for (uint256 i; i < _calldataLength; i++) {
+            __hashedCalldata[i] = keccak256(_calldata[i]);
+            // NOTE: We dont care if it reverts or not, if it does, sync should show that it reverted with the retdata
+            (,_retdata[i]) = _targets[i].call(_calldata[i]);
+        }
+    }
+}

--- a/packages/contracts-bedrock/src/L1/Sync.sol
+++ b/packages/contracts-bedrock/src/L1/Sync.sol
@@ -3,27 +3,28 @@ pragma solidity 0.8.15;
 
 
 contract Sync {
-
     error NotParallelArrays();
+    error NotEthCall();
 
     // NOTE: This is very expensive, for poc is fine, in production investigate optimizations
     bytes[] internal _calldata;
-    bytes[] internal _retdata;
     address[] internal _targets;
 
     // NOTE: For the sake of poc this is left open for anyone to call, in production this should be changed
     // NOTE: __retdata is unneccesary to save as we get it from sync() need to change this later
-    function setSync(bytes[] memory __calldata, bytes[]  memory __retdata, address[] memory __targets) external {
+    function setSync(bytes[] memory __calldata, address[] memory __targets) external {
          uint256 __calldataLength = __calldata.length;
-        if (__calldataLength != __retdata.length || __calldataLength != __targets.length) revert NotParallelArrays();
+        if (__calldataLength != __targets.length) revert NotParallelArrays();
 
         _calldata = __calldata;
-        _retdata = __retdata;
         _targets = __targets;
     }
 
     // NOTE: This function is only supposed to be called within the context of an `eth_call`
+    // We cant make it view because of arbitrary calldata could potentially mutate state
     function sync() external returns (address[] memory __targets, bytes[] memory __retdata, bytes32[] memory __hashedCalldata) {
+        if(msg.sender != address(0)) revert NotEthCall(); // the node will make an eth_call with from set as address(0)
+
         uint256 _calldataLength = _calldata.length;
         if (_calldataLength == 0) return (__targets, __retdata, __hashedCalldata);
 
@@ -31,8 +32,6 @@ contract Sync {
         __retdata = new bytes[](_calldataLength);
         __hashedCalldata = new bytes32[](_calldataLength);
 
-        // WARNING: This is broken and will potentially break for calldata's and return data's that are larger than 32 bytes
-        // Needs to be fixed for prod, fine for PoC
         for (uint256 i; i < _calldataLength; i++) {
             __hashedCalldata[i] = keccak256(_calldata[i]);
             // NOTE: We dont care if it reverts or not, if it does, sync should show that it reverted with the retdata

--- a/packages/contracts-bedrock/src/L1/Sync.sol
+++ b/packages/contracts-bedrock/src/L1/Sync.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.15;
 
 
 contract Sync {
+
     error NotParallelArrays();
 
     // NOTE: This is very expensive, for poc is fine, in production investigate optimizations
@@ -11,15 +12,14 @@ contract Sync {
     address[] internal _targets;
 
     // NOTE: For the sake of poc this is left open for anyone to call, in production this should be changed
-    function setSync(bytes[] calldata __calldata, bytes[] calldata __retdata, address[] calldata __targets) external {
+    // NOTE: __retdata is unneccesary to save as we get it from sync() need to change this later
+    function setSync(bytes[] memory __calldata, bytes[]  memory __retdata, address[] memory __targets) external {
          uint256 __calldataLength = __calldata.length;
         if (__calldataLength != __retdata.length || __calldataLength != __targets.length) revert NotParallelArrays();
 
-        for (uint256 i; i < __calldataLength; i++) {
-            _calldata[i] = __calldata[i];
-            _retdata[i] = __retdata[i];
-            _targets[i] = __targets[i];
-        }
+        _calldata = __calldata;
+        _retdata = __retdata;
+        _targets = __targets;
     }
 
     // NOTE: This function is only supposed to be called within the context of an `eth_call`
@@ -27,10 +27,17 @@ contract Sync {
         uint256 _calldataLength = _calldata.length;
         if (_calldataLength == 0) return (__targets, __retdata, __hashedCalldata);
 
+        __targets = new address[](_calldataLength);
+        __retdata = new bytes[](_calldataLength);
+        __hashedCalldata = new bytes32[](_calldataLength);
+
+        // WARNING: This is broken and will potentially break for calldata's and return data's that are larger than 32 bytes
+        // Needs to be fixed for prod, fine for PoC
         for (uint256 i; i < _calldataLength; i++) {
             __hashedCalldata[i] = keccak256(_calldata[i]);
             // NOTE: We dont care if it reverts or not, if it does, sync should show that it reverted with the retdata
-            (,_retdata[i]) = _targets[i].call(_calldata[i]);
+            (,__retdata[i]) = _targets[i].call(_calldata[i]);
+            __targets[i] = _targets[i];
         }
     }
 }

--- a/packages/contracts-bedrock/src/L1/Sync.sol
+++ b/packages/contracts-bedrock/src/L1/Sync.sol
@@ -11,7 +11,6 @@ contract Sync {
     address[] internal _targets;
 
     // NOTE: For the sake of poc this is left open for anyone to call, in production this should be changed
-    // NOTE: __retdata is unneccesary to save as we get it from sync() need to change this later
     function setSync(bytes[] memory __calldata, address[] memory __targets) external {
          uint256 __calldataLength = __calldata.length;
         if (__calldataLength != __targets.length) revert NotParallelArrays();

--- a/packages/contracts-bedrock/src/L2/Ethereum.sol
+++ b/packages/contracts-bedrock/src/L2/Ethereum.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import { L1Block } from "src/L2/L1Block.sol";
+import { Constants } from "src/libraries/Constants.sol";
+
+contract Ethereum {
+    error NotDepositor();
+    error NotParallelArrays();
+
+    L1Block internal constant L1_BLOCK = L1Block(0x4200000000000000000000000000000000000015);
+
+    mapping(address => mapping(bytes32 => bytes)) internal _state;
+    mapping(bytes32 => bytes32) internal latestBlockHashForCalldata;
+
+    function setState(address[] calldata _targets, bytes[] calldata _retdata, bytes32[] calldata _hashedCalldata) external {
+        if (msg.sender != Constants.DEPOSITOR_ACCOUNT) revert NotDepositor();
+
+        uint256 _targetsLength = _targets.length;
+        if (_targetsLength != _retdata.length || _targetsLength != _hashedCalldata.length) revert NotParallelArrays();
+        for (uint256 i; i < _targetsLength; i++) {
+            _state[_targets[i]][_hashedCalldata[i]] = _retdata[i];
+            latestBlockHashForCalldata[_hashedCalldata[i]] = L1_BLOCK.hash();
+        }
+    }
+
+    function call(address _target, bytes calldata _calldata) external view returns (bytes memory _retdata, bool _isStale) {
+        bytes32 _hashedCalldata = keccak256(_calldata);
+        _retdata = _state[_target][_hashedCalldata];
+        _isStale = L1_BLOCK.hash() != latestBlockHashForCalldata[_hashedCalldata];
+    }
+}

--- a/packages/contracts-bedrock/src/libraries/Predeploys.sol
+++ b/packages/contracts-bedrock/src/libraries/Predeploys.sol
@@ -99,6 +99,8 @@ library Predeploys {
     /// @notice Address of the OptimismSuperchainERC20Factory predeploy.
     address internal constant OPTIMISM_SUPERCHAIN_ERC20_FACTORY = 0x4200000000000000000000000000000000000026;
 
+    address internal constant ETHEREUM = 0x4200000000000000000000000000000000000027;
+
     /// @notice Returns the name of the predeploy at the given address.
     function getName(address _addr) internal pure returns (string memory out_) {
         require(isPredeployNamespace(_addr), "Predeploys: address must be a predeploy");
@@ -128,6 +130,7 @@ library Predeploys {
         if (_addr == SUPERCHAIN_WETH) return "SuperchainWETH";
         if (_addr == ETH_LIQUIDITY) return "ETHLiquidity";
         if (_addr == OPTIMISM_SUPERCHAIN_ERC20_FACTORY) return "OptimismSuperchainERC20Factory";
+        if (_addr == ETHEREUM) return "Ethereum";
         revert("Predeploys: unnamed predeploy");
     }
 
@@ -143,7 +146,7 @@ library Predeploys {
             || _addr == SEQUENCER_FEE_WALLET || _addr == OPTIMISM_MINTABLE_ERC20_FACTORY || _addr == L1_BLOCK_NUMBER
             || _addr == L2_ERC721_BRIDGE || _addr == L1_BLOCK_ATTRIBUTES || _addr == L2_TO_L1_MESSAGE_PASSER
             || _addr == OPTIMISM_MINTABLE_ERC721_FACTORY || _addr == PROXY_ADMIN || _addr == BASE_FEE_VAULT
-            || _addr == L1_FEE_VAULT || _addr == SCHEMA_REGISTRY || _addr == EAS || _addr == GOVERNANCE_TOKEN
+            || _addr == L1_FEE_VAULT || _addr == SCHEMA_REGISTRY || _addr == EAS || _addr == GOVERNANCE_TOKEN || _addr == ETHEREUM
             || (_useInterop && _addr == CROSS_L2_INBOX) || (_useInterop && _addr == L2_TO_L2_CROSS_DOMAIN_MESSENGER)
             || (_useInterop && _addr == SUPERCHAIN_WETH) || (_useInterop && _addr == ETH_LIQUIDITY)
             || (_useInterop && _addr == OPTIMISM_SUPERCHAIN_ERC20_FACTORY);

--- a/packages/contracts-bedrock/test/DeployImplementations.t.sol
+++ b/packages/contracts-bedrock/test/DeployImplementations.t.sol
@@ -13,6 +13,7 @@ import { L1CrossDomainMessenger } from "src/L1/L1CrossDomainMessenger.sol";
 import { L1ERC721Bridge } from "src/L1/L1ERC721Bridge.sol";
 import { L1StandardBridge } from "src/L1/L1StandardBridge.sol";
 import { OptimismMintableERC20Factory } from "src/universal/OptimismMintableERC20Factory.sol";
+import { Sync } from "src/L1/Sync.sol";
 
 import {
     DeployImplementationsInput,
@@ -88,7 +89,8 @@ contract DeployImplementationsOutput_Test is Test {
             l1CrossDomainMessengerImpl: L1CrossDomainMessenger(makeAddr("l1CrossDomainMessengerImpl")),
             l1ERC721BridgeImpl: L1ERC721Bridge(makeAddr("l1ERC721BridgeImpl")),
             l1StandardBridgeImpl: L1StandardBridge(payable(makeAddr("l1StandardBridgeImpl"))),
-            optimismMintableERC20FactoryImpl: OptimismMintableERC20Factory(makeAddr("optimismMintableERC20FactoryImpl"))
+            optimismMintableERC20FactoryImpl: OptimismMintableERC20Factory(makeAddr("optimismMintableERC20FactoryImpl")),
+            sync: Sync(makeAddr("sync"))
         });
 
         vm.etch(address(output.optimismPortal2Impl), hex"01");
@@ -100,6 +102,7 @@ contract DeployImplementationsOutput_Test is Test {
         vm.etch(address(output.l1ERC721BridgeImpl), hex"01");
         vm.etch(address(output.l1StandardBridgeImpl), hex"01");
         vm.etch(address(output.optimismMintableERC20FactoryImpl), hex"01");
+        vm.etch(address(output.sync), hex"01");
 
         dso.set(dso.optimismPortal2Impl.selector, address(output.optimismPortal2Impl));
         dso.set(dso.delayedWETHImpl.selector, address(output.delayedWETHImpl));
@@ -110,6 +113,7 @@ contract DeployImplementationsOutput_Test is Test {
         dso.set(dso.l1ERC721BridgeImpl.selector, address(output.l1ERC721BridgeImpl));
         dso.set(dso.l1StandardBridgeImpl.selector, address(output.l1StandardBridgeImpl));
         dso.set(dso.optimismMintableERC20FactoryImpl.selector, address(output.optimismMintableERC20FactoryImpl));
+        dso.set(dso.sync.selector, address(output.sync));
 
         assertEq(address(output.optimismPortal2Impl), address(dso.optimismPortal2Impl()), "100");
         assertEq(address(output.delayedWETHImpl), address(dso.delayedWETHImpl()), "200");


### PR DESCRIPTION
**Description**

A PoC of the "Sync function" with customizable composability made as a PR for visibility, not meant for merging or production use.

How it works:

1. Random user (should be changed if this went to prod) can set which functions to sync to L2, through the L1 `Sync` contract
1. Node will call `sync()` through an `eth_call` in the derivation pipeline and create a `syncTx` to be mined on L2 that will hold the outputted data
1. Appends a new `syncTx` in the derivation` PayloadAttributes` right after the `L1Block` update tx, will always be 2nd in block
1. Anyone can call `Ethereum.call(_target, _calldata)` which is a new L2 contract to fetch the synced state from, it returns the data and if it is stale or not.

**Tests**

Tests were not updated and these changes caused several to fail

